### PR TITLE
Update references to ThemeProvider to point to StreetscapeProvider

### DIFF
--- a/.storybook/ThemeBlock.tsx
+++ b/.storybook/ThemeBlock.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Unstyled } from "@storybook/blocks";
-import { ThemeProvider } from "../src/ThemeProvider";
+import { StreetscapeProvider } from "../src/StreetscapeProvider";
 
 interface ThemeBlockProps {
   children: React.ReactNode;
@@ -8,6 +8,6 @@ interface ThemeBlockProps {
 
 export const ThemeBlock = ({ children }: ThemeBlockProps) => (
   <Unstyled>
-    <ThemeProvider>{children}</ThemeProvider>
+    <StreetscapeProvider>{children}</StreetscapeProvider>
   </Unstyled>
 );

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import type { Preview } from "@storybook/react";
-import { ThemeProvider } from "../src/ThemeProvider";
+import { StreetscapeProvider } from "../src/StreetscapeProvider";
 
 const preview: Preview = {
   parameters: {
@@ -14,9 +14,9 @@ const preview: Preview = {
   },
   decorators: [
     (Story) => (
-      <ThemeProvider>
+      <StreetscapeProvider>
         <Story />
-      </ThemeProvider>
+      </StreetscapeProvider>
     ),
   ],
 };


### PR DESCRIPTION
# Changes
This PR updates some references to `ThemeProvider` that were leftover after that component was renamed to `StreetscapeProvider`