### PR TITLE
33 Add Accordion component and stories

### DIFF
--- a/src/components/Accordion/Accordion.stories.tsx
+++ b/src/components/Accordion/Accordion.stories.tsx
@@ -1,0 +1,75 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { chakra } from "@chakra-ui/system";
+import { Box } from "@chakra-ui/react";
+import { getThemingArgTypes } from "@chakra-ui/storybook-addon";
+import {
+  Accordion,
+  AccordionItem,
+  AccordionButton,
+  AccordionPanel,
+  AccordionIcon,
+} from "./Accordion";
+import { theme } from "../../theme";
+
+const meta = {
+  title: "Components/Accordion",
+  component: Accordion,
+  tags: ["autodocs"],
+  argTypes: {
+    ...getThemingArgTypes(theme, "Accordion"),
+  },
+  decorators: [
+    // Because <Accordion> defaults to 100% width, wrap stories in div with max width.
+    (Story) => <chakra.div maxW="560px">{Story()}</chakra.div>,
+  ],
+} satisfies Meta<typeof Accordion>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Base: Story = {
+  args: {
+    allowMultiple: true,
+    allowToggle: false,
+  },
+  render: (args) => (
+    <Accordion
+      allowMultiple={args.allowMultiple}
+      allowToggle={args.allowToggle}
+    >
+      <AccordionItem>
+        <h2>
+          <AccordionButton>
+            <Box as="span" flex="1" textAlign="left">
+              Section 1 title
+            </Box>
+            <AccordionIcon />
+          </AccordionButton>
+        </h2>
+        <AccordionPanel pb={4}>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+          aliquip ex ea commodo consequat.
+        </AccordionPanel>
+      </AccordionItem>
+
+      <AccordionItem>
+        <h2>
+          <AccordionButton>
+            <Box as="span" flex="1" textAlign="left">
+              Section 2 title
+            </Box>
+            <AccordionIcon />
+          </AccordionButton>
+        </h2>
+        <AccordionPanel pb={4}>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+          aliquip ex ea commodo consequat.
+        </AccordionPanel>
+      </AccordionItem>
+    </Accordion>
+  ),
+};

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -1,0 +1,29 @@
+import { Accordion as ChakraAccordion } from "@chakra-ui/react";
+import type { AccordionProps as ChakraAccordionProps } from "@chakra-ui/react";
+
+export const Accordion = ChakraAccordion;
+export interface AccordionProps extends ChakraAccordionProps {}
+
+import { AccordionItem as ChakraAccordionItem } from "@chakra-ui/react";
+import type { AccordionItemProps as ChakraAccordionItemProps } from "@chakra-ui/react";
+
+export const AccordionItem = ChakraAccordionItem;
+export interface AccordionItemProps extends ChakraAccordionItemProps {}
+
+import { AccordionButton as ChakraAccordionButton } from "@chakra-ui/react";
+import type { AccordionButtonProps as ChakraAccordionButtonProps } from "@chakra-ui/react";
+
+export const AccordionButton = ChakraAccordionButton;
+export interface AccordionButtonProps extends ChakraAccordionButtonProps {}
+
+import { AccordionPanel as ChakraAccordionPanel } from "@chakra-ui/react";
+import type { AccordionPanelProps as ChakraAccordionPanelProps } from "@chakra-ui/react";
+
+export const AccordionPanel = ChakraAccordionPanel;
+export interface AccordionPanelProps extends ChakraAccordionPanelProps {}
+
+import { AccordionIcon as ChakraAccordionIcon } from "@chakra-ui/react";
+import type { IconProps as ChakraIconProps } from "@chakra-ui/react";
+
+export const AccordionIcon = ChakraAccordionIcon;
+export interface AccordionIconProps extends ChakraIconProps {}

--- a/src/components/Accordion/index.ts
+++ b/src/components/Accordion/index.ts
@@ -1,0 +1,14 @@
+export {
+  Accordion,
+  AccordionItem,
+  AccordionButton,
+  AccordionPanel,
+  AccordionIcon,
+} from "./Accordion";
+export type {
+  AccordionProps,
+  AccordionItemProps,
+  AccordionButtonProps,
+  AccordionPanelProps,
+  AccordionIconProps,
+} from "./Accordion";

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,3 +1,4 @@
+export * from "./Accordion";
 export * from "./Button";
 export * from "./Checkbox";
 export * from "./Switch";

--- a/src/theme/components/accordion.ts
+++ b/src/theme/components/accordion.ts
@@ -1,0 +1,39 @@
+import { accordionAnatomy as parts } from "@chakra-ui/anatomy";
+import {
+  createMultiStyleConfigHelpers,
+  defineStyle,
+} from "@chakra-ui/styled-system";
+import { accordionTheme as chakraAccordionTheme } from "@chakra-ui/theme/components/accordion";
+
+const { definePartsStyle, defineMultiStyleConfig } =
+  createMultiStyleConfigHelpers(parts.keys);
+
+const baseStyleContainer = defineStyle({
+  ...chakraAccordionTheme.baseStyle?.container,
+  borderColor: "gray.200",
+});
+
+const baseStyleButton = defineStyle({
+  ...chakraAccordionTheme.baseStyle?.button,
+  _hover: {
+    ...chakraAccordionTheme.baseStyle?.button._hover,
+    bg: "gray.50",
+  },
+});
+
+const baseStylePanel = defineStyle({
+  ...chakraAccordionTheme.baseStyle?.panel,
+});
+
+const baseStyleIcon = defineStyle({
+  ...chakraAccordionTheme.baseStyle?.icon,
+});
+
+const baseStyle = definePartsStyle({
+  container: baseStyleContainer,
+  button: baseStyleButton,
+  panel: baseStylePanel,
+  icon: baseStyleIcon,
+});
+
+export const accordionTheme = defineMultiStyleConfig({ baseStyle });

--- a/src/theme/components/index.ts
+++ b/src/theme/components/index.ts
@@ -1,8 +1,10 @@
+import { accordionTheme } from "./accordion";
 import { buttonTheme } from "./button";
 import { checkboxTheme } from "./checkbox";
 import { switchTheme } from "./switch";
 
 export const components = {
+  Accordion: accordionTheme,
   Button: buttonTheme,
   Checkbox: checkboxTheme,
   Switch: switchTheme,


### PR DESCRIPTION
Completes #33 

Implement the Accordion component needed for the [Layers and Filters UI](https://github.com/NYCPlanning/ae-zoning-map-poc/issues/8). Note that this component is only for the collapsable sections _inside_ the Layers and Filters widget such as Zoning Districts, Commercial Districts, etc. We won't use it for collapsing the widget itself. This will use [Chakra's Accordion component](https://chakra-ui.com/docs/components/accordion/usage).

* Because the functionality we need is essentially the same as [Chakra's default theme](https://github.com/chakra-ui/chakra-ui/blob/main/packages/components/theme/src/components/accordion.ts), we should try just importing that, making any small changes as needed ([such as overwriting `blackAlpha.50` color that doesn't exist in our colors tokens](https://github.com/chakra-ui/chakra-ui/blob/main/packages/components/theme/src/components/accordion.ts#L26)) and using that in Streetscape
* This component won't have any sizes or variants, just like the default
* Create one Storybook story for this component called "Base", with some placeholder content in the AccordionButton and AccordionPanel