### PR TITLE
28 Add Select component and stories

### DIFF
--- a/src/components/FormControl/FormControl.stories.tsx
+++ b/src/components/FormControl/FormControl.stories.tsx
@@ -5,6 +5,7 @@ import { FormControl } from "./FormControl";
 import { FormErrorMessage } from "./FormErrorMessage";
 import { FormLabel } from "./FormLabel";
 import { Input } from "../Input";
+import { Select as FormControlSelect } from "../Select";
 import { theme } from "../../theme";
 
 const meta = {
@@ -59,6 +60,29 @@ export const Error: Story = {
     <FormControl id="input-component" {...args}>
       <FormLabel>Input Label</FormLabel>
       <Input placeholder="Placeholder Text" />
+      <FormErrorMessage>This is an error message.</FormErrorMessage>
+    </FormControl>
+  ),
+};
+
+export const Select: Story = {
+  args: {
+    isRequired: false,
+    isInvalid: false,
+  },
+  render: (args) => (
+    <FormControl
+      id="select-component"
+      // Props should reference args, otherwise changes to StoryBook controls will not be reflected
+      isRequired={args.isRequired}
+      isInvalid={args.isInvalid}
+    >
+      <FormLabel>Select Label</FormLabel>
+      <FormControlSelect placeholder="Placeholder Text">
+        <option value="option1">Option 1</option>
+        <option value="option2">Option 2</option>
+        <option value="option3">Option 3</option>
+      </FormControlSelect>
       <FormErrorMessage>This is an error message.</FormErrorMessage>
     </FormControl>
   ),

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { chakra } from "@chakra-ui/system";
+import { getThemingArgTypes } from "@chakra-ui/storybook-addon";
+import { Select } from "./Select";
+import { theme } from "../../theme";
+
+const meta = {
+  title: "Components/Select",
+  component: Select,
+  tags: ["autodocs"],
+  argTypes: {
+    ...getThemingArgTypes(theme, "Select"),
+    placeholder: { type: "string" },
+  },
+  decorators: [
+    // Because <Select> defaults to 100% width, wrap stories in div with max width.
+    (Story) => <chakra.div maxW="560px">{Story()}</chakra.div>,
+  ],
+} satisfies Meta<typeof Select>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Base: Story = {
+  args: {
+    placeholder: "Placeholder Text",
+    size: "md",
+    variant: "base",
+  },
+};
+
+export const Invalid: Story = {
+  args: {
+    placeholder: "Placeholder Text",
+    size: "md",
+    variant: "base",
+    isInvalid: true,
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    placeholder: "Placeholder Text",
+    size: "md",
+    variant: "base",
+    isDisabled: true,
+  },
+};

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -1,0 +1,5 @@
+import { Select as ChakraSelect } from "@chakra-ui/react";
+import type { SelectProps as ChakraSelectProps } from "@chakra-ui/react";
+
+export const Select = ChakraSelect;
+export interface SelectProps extends ChakraSelectProps {}

--- a/src/components/Select/index.ts
+++ b/src/components/Select/index.ts
@@ -1,0 +1,2 @@
+export { Select } from "./Select";
+export type { SelectProps } from "./Select";

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -4,3 +4,4 @@ export * from "./Checkbox";
 export * from "./Switch";
 export * from "./Input";
 export * from "./FormControl";
+export * from "./Select";

--- a/src/theme/components/index.ts
+++ b/src/theme/components/index.ts
@@ -6,6 +6,7 @@ import { inputTheme } from "./input";
 import { formControlTheme } from "./form-control";
 import { formLabelTheme } from "./form-label";
 import { formErrorTheme } from "./form-error";
+import { selectTheme } from "./select";
 
 export const components = {
   Accordion: accordionTheme,
@@ -16,4 +17,5 @@ export const components = {
   FormControl: formControlTheme,
   FormError: formErrorTheme,
   FormLabel: formLabelTheme,
+  Select: selectTheme,
 };

--- a/src/theme/components/select.ts
+++ b/src/theme/components/select.ts
@@ -1,0 +1,67 @@
+// import { defineStyleConfig } from "@chakra-ui/react";
+import { selectAnatomy as parts } from "@chakra-ui/anatomy";
+import { createMultiStyleConfigHelpers } from "@chakra-ui/styled-system";
+import { inputTheme } from "./input";
+import { defineStyle } from "@chakra-ui/styled-system";
+
+const { definePartsStyle, defineMultiStyleConfig } =
+  createMultiStyleConfigHelpers(parts.keys);
+
+const baseStyle = definePartsStyle({
+  icon: {
+    width: "6",
+    height: "100%",
+    insetEnd: "2",
+    position: "relative",
+    color: "currentColor",
+    fontSize: "xl",
+    _disabled: {
+      opacity: 0.5,
+    },
+  },
+  field: {
+    ...inputTheme.baseStyle?.field,
+    appearance: "none",
+    bg: "white",
+  },
+});
+
+const iconSpacing = defineStyle({
+  paddingInlineEnd: "8",
+});
+
+const sizes = {
+  lg: {
+    ...inputTheme.sizes?.lg,
+    field: {
+      ...inputTheme.sizes?.lg.field,
+      ...iconSpacing,
+    },
+  },
+  md: {
+    ...inputTheme.sizes?.md,
+    field: {
+      ...inputTheme.sizes?.md.field,
+      ...iconSpacing,
+    },
+  },
+  sm: {
+    ...inputTheme.sizes?.sm,
+    field: {
+      ...inputTheme.sizes?.sm.field,
+      ...iconSpacing,
+    },
+  },
+};
+
+export const selectTheme = defineMultiStyleConfig({
+  baseStyle,
+  sizes,
+  variants: {
+    base: {},
+  },
+  defaultProps: {
+    size: "md",
+    variant: "base",
+  },
+});


### PR DESCRIPTION
Completes #28 

Implement our Select component and it's various sizes and states as per the [Figma specs](https://www.figma.com/file/i6Vvsi3UvR32mB8w8Qs80P/Design-System?node-id=2024%3A6823&mode=dev) in the [ae-streetscape repo](https://github.com/NYCPlanning/ae-streetscape). The designs show three sizes - "sm", "md", and "lg". There is only one variant, which we can refer to as "base" in our Chakra theming.

* Set the default size to `md` and the default variant to `base`
* Add three stories, with `md` and `base` set for all:
    * "Base" - Default state
    * "Error" - Has `isInvalid` set to `true`
    * "Disabled" - Has `isDisabled` set to `True`

This component will use [Chakra UI's Select](https://chakra-ui.com/docs/components/select/usage).