### PR TITLE
Fix prop name for form control in theme so styles are applied correctly

### DIFF
--- a/src/theme/components/index.ts
+++ b/src/theme/components/index.ts
@@ -14,7 +14,7 @@ export const components = {
   Checkbox: checkboxTheme,
   Switch: switchTheme,
   Input: inputTheme,
-  FormControl: formControlTheme,
+  Form: formControlTheme,
   FormError: formErrorTheme,
   FormLabel: formLabelTheme,
   Select: selectTheme,


### PR DESCRIPTION
This fixes a bug where the theme for the `FormControl` component was being passed in as `FormControl` on the components object with the theme. Chakra (perhaps confusingly) expects it to be called [Form](https://github.com/chakra-ui/chakra-ui/blob/main/packages/components/theme/src/components/index.ts#L100). This bug was causing the styles to not be applied to the FormControl component.