### PR TITLE
fix(CloseButton): Fixes export for CloseButton and CloseButtonProps

### DIFF
--- a/src/components/CloseButton/index.ts
+++ b/src/components/CloseButton/index.ts
@@ -1,1 +1,2 @@
-export * from "./CloseButton";
+export { CloseButton } from "./CloseButton";
+export type { CloseButtonProps } from "./CloseButton";


### PR DESCRIPTION
This PR fixes a bug introduced in #52 where the `CloseButton` was added but the barrel file for it wasn't correctly re-exporting the component and it's props type.