### PR TITLE
91 Button component pushing down content on hover

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,5 +1,17 @@
 import { Button as ChakraButton } from "@chakra-ui/react";
 import type { ButtonProps as ChakraButtonProps } from "@chakra-ui/react";
+import * as React from "react";
 
-export const Button = ChakraButton;
+export const Button = React.forwardRef(function Button(
+  props: ChakraButtonProps,
+  ref: React.ForwardedRef<unknown>,
+) {
+  const { children, ...rest } = props;
+  return (
+    <ChakraButton data-label={children} ref={ref} {...rest}>
+      {children}
+    </ChakraButton>
+  );
+});
+
 export interface ButtonProps extends ChakraButtonProps {}

--- a/src/theme/components/button.ts
+++ b/src/theme/components/button.ts
@@ -2,6 +2,7 @@ import { defineStyleConfig } from "@chakra-ui/react";
 
 export const buttonTheme = defineStyleConfig({
   baseStyle: {
+    border: "1px solid rgba(255, 255, 255, 0)",
     borderRadius: "base",
     px: 6,
     py: 3,

--- a/src/theme/components/button.ts
+++ b/src/theme/components/button.ts
@@ -7,6 +7,15 @@ export const buttonTheme = defineStyleConfig({
     px: 6,
     py: 3,
     whiteSpace: "normal",
+    display: "inline-block",
+    _before: {
+      display: "block",
+      content: "attr(data-label)",
+      fontWeight: "medium",
+      height: 0,
+      overflow: "hidden",
+      visibility: "hidden",
+    },
   },
   sizes: {
     xs: {


### PR DESCRIPTION
Related to https://github.com/NYCPlanning/ae-cp-map/issues/155. There is an issue where the height of the `<Button>` component increases on hover due to the border showing on hover. This causes visual bugs where content below the component is "pushed" down.

![Image](https://github.com/user-attachments/assets/7b5c7a80-555d-49a8-9198-f0edaf38b710)

### Acceptance Criteria:

- [x] Update `<Button>` styles to account for change in height on hover
- [x] Update `<Button>` styles to account for change in width on hover
- [x] Account for this issue in all variants

UPDATE: Also includes changes to complete #90 
- [x] For accessibility we need to add a focus prop so when a user tabs into a button, they see the same CSS styles as if they hovered the mouse over the button.

The issue of the height change was corrected by adding a 1 pixel transparent border to the base style, to match the border of the hover state.

The issue of the width change was caused by the change in `fontWeight` on hover.  To correct this, I used the ::before pseudo-element to insert an invisible copy of the button's text with the same `fontWeight` as the hover, which increases the base width to that of the hover state. 

Closes #90 and #91