### PR TITLE
Add missing export for Number Input component to barrel file

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -4,6 +4,7 @@ export * from "./CloseButton";
 export * from "./Checkbox";
 export * from "./Switch";
 export * from "./Input";
+export * from "./NumberInput";
 export * from "./FormControl";
 export * from "./Select";
 export * from "./Drawer";


### PR DESCRIPTION
This PR adds a missing export to `/src/components/index.ts` for the `NumberInput` component originally added in #94 