### PR TITLE
96 Fix NumberInput size issues

### DIFF
--- a/src/theme/components/number-input.ts
+++ b/src/theme/components/number-input.ts
@@ -8,30 +8,10 @@ import { inputTheme } from "./input";
 const { definePartsStyle, defineMultiStyleConfig } =
   createMultiStyleConfigHelpers(parts.keys);
 
-const baseStyle = definePartsStyle({
-  addon: inputTheme.baseStyle?.addon,
-  field: {
-    ...inputTheme.baseStyle?.field,
-    _invalid: {
-      outline: 0,
-      border: 0,
-      ring: "2px",
-      ringColor: "state.error",
-    },
-    _focusVisible: {
-      outline: 0,
-      border: 0,
-      ring: "2px",
-      ringColor: "state.focus",
-    },
-  },
-});
-
 const stepper = defineStyle({
   margin: 0.25,
   paddingX: 2,
   fontSize: "xs",
-  backgroundColor: "gray.100",
   _odd: {
     borderTopRightRadius: "base",
   },
@@ -56,7 +36,7 @@ const sizes = {
 };
 
 export const numberInputTheme = defineMultiStyleConfig({
-  baseStyle,
+  baseStyle: inputTheme.baseStyle,
   sizes,
   variants: inputTheme.variants,
   defaultProps: inputTheme.defaultProps,


### PR DESCRIPTION
The way we had been doing the borders for the number input component was causing issues in CP Map.

<img width="391" alt="Image" src="https://github.com/user-attachments/assets/06f76361-c749-42c1-a2e8-4b2e5eebdff2" />

The issue is that by default the stepper field appears on top of the border of the input, which looks terrible: 
<img width="662" alt="image" src="https://github.com/user-attachments/assets/4c212d51-46d5-4479-b318-866b0d23a0a0" />

To compensate, in the previous PR I used the "ring" property instead of the border, which solved the problem.  However, it does also change the size, causing the problem in the first screenshot.  The solution, as discussed with @Ntoal, is to revert to the default of to using the border property, and removing any background color from the number input stepper.