### PR TITLE
101 Add skeleton component

### DIFF
--- a/src/components/Skeleton/Skeleton.stories.tsx
+++ b/src/components/Skeleton/Skeleton.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { getThemingArgTypes } from "@chakra-ui/storybook-addon";
+import { Skeleton } from "./Skeleton";
+import { theme } from "../../theme";
+
+const meta = {
+  title: "Components/Skeleton",
+  component: Skeleton,
+  tags: ["autodocs"],
+  argTypes: {
+    ...getThemingArgTypes(theme, "Skeleton"),
+    children: { type: "string" },
+  },
+} satisfies Meta<typeof Skeleton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {
+  args: {},
+  render: function Render(args) {
+    return (
+      <Skeleton {...args}>
+        <div>contents wrapped</div>
+        <div>will not be visible</div>
+      </Skeleton>
+    );
+  },
+};

--- a/src/components/Skeleton/Skeleton.tsx
+++ b/src/components/Skeleton/Skeleton.tsx
@@ -1,0 +1,18 @@
+import {
+  Skeleton as ChakraSkeleton,
+  SkeletonCircle as ChakraSkeletonCircle,
+  SkeletonText as ChakraSkeletonText,
+} from "@chakra-ui/react";
+import {
+  SkeletonProps as ChakraSkeletonProps,
+  SkeletonTextProps as ChakraSkeletonTextProps,
+} from "@chakra-ui/react";
+
+export const Skeleton = ChakraSkeleton;
+export interface SkeletonProps extends ChakraSkeletonProps {}
+
+export const SkeletonCircle = ChakraSkeletonCircle;
+export interface SkeletonCircleProps extends ChakraSkeletonProps {}
+
+export const SkeletonText = ChakraSkeletonText;
+export interface SkeletonTextProps extends ChakraSkeletonTextProps {}

--- a/src/components/Skeleton/index.ts
+++ b/src/components/Skeleton/index.ts
@@ -1,0 +1,6 @@
+export { Skeleton, SkeletonCircle, SkeletonText } from "./Skeleton";
+export type {
+  SkeletonProps,
+  SkeletonCircleProps,
+  SkeletonTextProps,
+} from "./Skeleton";

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -11,3 +11,4 @@ export * from "./Drawer";
 export * from "./Table";
 export * from "./Transitions";
 export * from "./Modal";
+export * from "./Skeleton";

--- a/src/theme/components/index.ts
+++ b/src/theme/components/index.ts
@@ -12,6 +12,7 @@ import { closeButtonTheme } from "./close-button";
 import { drawerTheme } from "./drawer";
 import { tableTheme } from "./table";
 import { modalTheme } from "./modal";
+import { skeletonTheme } from "./skeleton";
 
 export const components = {
   Accordion: accordionTheme,
@@ -28,4 +29,5 @@ export const components = {
   Drawer: drawerTheme,
   Table: tableTheme,
   Modal: modalTheme,
+  Skeleton: skeletonTheme,
 };

--- a/src/theme/components/skeleton.ts
+++ b/src/theme/components/skeleton.ts
@@ -1,0 +1,3 @@
+import { skeletonTheme as chakraSkeletonTheme } from "@chakra-ui/theme/components/skeleton";
+
+export const skeletonTheme = chakraSkeletonTheme;

--- a/src/theme/tokens/radii.ts
+++ b/src/theme/tokens/radii.ts
@@ -1,6 +1,7 @@
 export const radii = {
   none: "0",
   base: "0.75rem",
+  sm: "0.25rem",
   md: "0.375rem",
   full: "9999px",
 };


### PR DESCRIPTION
Add [Skeleton](https://v2.chakra-ui.com/docs/components/skeleton/usage) component from Chakra to Streetscape

### Acceptance Criteria

- [x] Export all necessary components and types so applications that install Streetscape package have access
- [x] Component styling should match default styling as seen in Chakra docs. [Here](https://github.com/chakra-ui/chakra-ui/blob/%40chakra-ui/react%402.10.9/packages/theme/src/components/skeleton.ts) is the Chakra v2 theme file for the component for reference. Simply import and reuse this if possible
- [x] All styling can be applied to the base styling, no variants/sizes necessary
- [x] Create Storybook story showing skeleton component in default state. Feel free to create other stories as you see fit.

Completes #101 