### PR TITLE
102 Add Tabs component

### DIFF
--- a/src/components/Tabs/Tabs.stories.tsx
+++ b/src/components/Tabs/Tabs.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { getThemingArgTypes } from "@chakra-ui/storybook-addon";
+import { Tabs, TabList, TabPanel, TabPanels, Tab } from "./Tabs";
+import { theme } from "../../theme";
+
+const meta = {
+  title: "Components/Tabs",
+  component: Tabs,
+  tags: ["autodocs"],
+  argTypes: {
+    ...getThemingArgTypes(theme, "Tabs"),
+  },
+} satisfies Meta<typeof Tabs>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Base: Story = {
+  args: {
+    children: (
+      <>
+        <TabList key={"TabList"}>
+          <Tab key={"Tab 1"}>One</Tab>
+          <Tab key={"Tab 2"}>Two</Tab>
+          <Tab key={"Tab 3"}>Three</Tab>
+        </TabList>
+        <TabPanels key={"TabPanels"}>
+          <TabPanel key={"TabPanel 1"}>
+            <p>one!</p>
+          </TabPanel>
+          <TabPanel key={"TabPanel 2"}>
+            <p>two!</p>
+          </TabPanel>
+          <TabPanel key={"TabPanel 3"}>
+            <p>three!</p>
+          </TabPanel>
+        </TabPanels>
+      </>
+    ),
+  },
+  render: function Render(args) {
+    return <Tabs {...args} />;
+  },
+};

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -1,0 +1,29 @@
+import { Tabs as ChakraTabs } from "@chakra-ui/react";
+import type { TabsProps as ChakraTabsProps } from "@chakra-ui/react";
+
+export const Tabs = ChakraTabs;
+export interface TabsProps extends ChakraTabsProps {}
+
+import { Tab as ChakraTab } from "@chakra-ui/react";
+import type { TabProps as ChakraTabProps } from "@chakra-ui/react";
+
+export const Tab = ChakraTab;
+export interface TabProps extends ChakraTabProps {}
+
+import { TabList as ChakraTabList } from "@chakra-ui/react";
+import type { TabListProps as ChakraTabListProps } from "@chakra-ui/react";
+
+export const TabList = ChakraTabList;
+export interface TabListProps extends ChakraTabListProps {}
+
+import { TabPanels as ChakraTabPanels } from "@chakra-ui/react";
+import type { TabPanelsProps as ChakraTabPanelsProps } from "@chakra-ui/react";
+
+export const TabPanels = ChakraTabPanels;
+export interface TabPanelsProps extends ChakraTabPanelsProps {}
+
+import { TabPanel as ChakraTabPanel } from "@chakra-ui/react";
+import type { TabPanelProps as ChakraTabPanelProps } from "@chakra-ui/react";
+
+export const TabPanel = ChakraTabPanel;
+export interface TabPanelProps extends ChakraTabPanelProps {}

--- a/src/components/Tabs/index.ts
+++ b/src/components/Tabs/index.ts
@@ -1,0 +1,8 @@
+export { Tabs, TabList, TabPanels, Tab, TabPanel } from "./Tabs";
+export type {
+  TabsProps,
+  TabListProps,
+  TabPanelsProps,
+  TabProps,
+  TabPanelProps,
+} from "./Tabs";

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -8,6 +8,7 @@ export * from "./NumberInput";
 export * from "./FormControl";
 export * from "./Select";
 export * from "./Drawer";
+export * from "./Tabs";
 export * from "./Table";
 export * from "./Transitions";
 export * from "./Modal";

--- a/src/theme/components/index.ts
+++ b/src/theme/components/index.ts
@@ -11,6 +11,7 @@ import { selectTheme } from "./select";
 import { closeButtonTheme } from "./close-button";
 import { drawerTheme } from "./drawer";
 import { tableTheme } from "./table";
+import { tabsTheme } from "./tabs";
 import { modalTheme } from "./modal";
 
 export const components = {
@@ -27,5 +28,6 @@ export const components = {
   CloseButton: closeButtonTheme,
   Drawer: drawerTheme,
   Table: tableTheme,
+  Tabs: tabsTheme,
   Modal: modalTheme,
 };

--- a/src/theme/components/tabs.ts
+++ b/src/theme/components/tabs.ts
@@ -1,0 +1,84 @@
+import { tabsAnatomy } from "@chakra-ui/anatomy";
+import { createMultiStyleConfigHelpers, defineStyle } from "@chakra-ui/react";
+
+const { definePartsStyle, defineMultiStyleConfig } =
+  createMultiStyleConfigHelpers(tabsAnatomy.keys);
+
+const baseStyleRoot = defineStyle((props) => {
+  const { orientation } = props;
+  return {
+    display: orientation === "vertical" ? "flex" : "block",
+    alignItems: "flex-start",
+    alignSelf: "stretch",
+  };
+});
+
+const baseStyleTab = defineStyle((props) => {
+  const { isFitted } = props;
+
+  return {
+    flex: isFitted ? 1 : undefined,
+    transitionProperty: "common",
+    transitionDuration: "normal",
+    paddingX: 3,
+    paddingY: 4,
+    background: "white",
+    textAlign: "center",
+    fontFamily: "Helvetica Neue",
+    fontWeight: 500,
+    fontSize: "sm",
+    _focusVisible: {
+      zIndex: 1,
+      boxShadow: "outline",
+    },
+    _disabled: {
+      cursor: "not-allowed",
+      opacity: 0.4,
+    },
+    _selected: {
+      color: "primary.700",
+      fontWeight: 700,
+      borderColor: "primary.600",
+      borderBottom: "4px solid",
+      paddingTop: 5,
+    },
+  };
+});
+
+const baseStyleTablist = defineStyle((props) => {
+  const { align = "start", orientation } = props;
+
+  const alignments: Record<string, string> = {
+    end: "flex-end",
+    center: "center",
+    start: "flex-start",
+  };
+
+  return {
+    justifyContent: alignments[align],
+    flexDirection: orientation === "vertical" ? "column" : "row",
+  };
+});
+
+const baseStyleTabpanel = defineStyle({
+  p: 4,
+});
+
+const baseStyle = definePartsStyle((props) => ({
+  root: baseStyleRoot(props),
+  tab: baseStyleTab(props),
+  tablist: baseStyleTablist(props),
+  tabpanel: baseStyleTabpanel,
+}));
+
+const variants = {
+  base: {},
+};
+
+export const tabsTheme = defineMultiStyleConfig({
+  baseStyle,
+  variants,
+  defaultProps: {
+    variant: "base",
+  },
+});

--- a/src/theme/components/tabs.ts
+++ b/src/theme/components/tabs.ts
@@ -29,7 +29,7 @@ const baseStyleTab = defineStyle((props) => {
     fontSize: "sm",
     _focusVisible: {
       zIndex: 1,
-      boxShadow: "outline",
+      boxShadow: "0 0 0 3px rgba(66, 153, 225, 0.6)",
     },
     _disabled: {
       cursor: "not-allowed",
@@ -57,6 +57,7 @@ const baseStyleTablist = defineStyle((props) => {
   return {
     justifyContent: alignments[align],
     flexDirection: orientation === "vertical" ? "column" : "row",
+    boxShadow: "0 1px 0 0 rgba(0, 0, 0, 0.08)",
   };
 });
 


### PR DESCRIPTION
Add [Tabs](https://v2.chakra-ui.com/docs/components/tabs/usage) component from Chakra to Streetscape

### Acceptance Criteria

- [x] Export all necessary components and types so applications that install Streetscape package have access
- [x] Including one variant called `base` with styling matching tabs [as seen in CPP designs](https://www.figma.com/design/LYHHoPop9l0jpEivk5CFzJ/Capital-Projects-Portal?node-id=4601-51492&m=dev)
- [x] Create Storybook story showing Tabs component in default state with `base` variant. Feel free to create other stories as you see fit.

Closes #102