### PR TITLE
Add customized implementation of Chakra Tooltip component

### DIFF
--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { InfoIcon } from "@chakra-ui/icons";
+import { getThemingArgTypes } from "@chakra-ui/storybook-addon";
+import { Tooltip } from "./Tooltip";
+import { theme } from "../../theme";
+
+const meta = {
+  title: "Components/Tooltip",
+  component: Tooltip,
+  tags: ["autodocs"],
+  argTypes: {
+    ...getThemingArgTypes(theme, "Tooltip"),
+    children: { type: "string" },
+  },
+} satisfies Meta<typeof Tooltip>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {
+  args: {
+    children: <InfoIcon />,
+    label: "Tooltip text",
+  },
+};
+
+export const WithArrow: Story = {
+  args: {
+    children: <InfoIcon />,
+    label: "Tooltip text",
+    hasArrow: true,
+    placement: "right",
+  },
+};

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -1,0 +1,35 @@
+import { useRef } from "react";
+import {
+  Tooltip as ChakraTooltip,
+  useOutsideClick,
+  useBoolean,
+  chakra,
+} from "@chakra-ui/react";
+import type { TooltipProps as ChakraTooltipProps } from "@chakra-ui/react";
+
+export interface TooltipProps extends ChakraTooltipProps {}
+export const Tooltip = ({
+  children,
+  ...restToolTipProps
+}: ChakraTooltipProps) => {
+  const ref = useRef(null);
+  const [isOpen, setIsLabelOpen] = useBoolean(false);
+  useOutsideClick({
+    ref: ref,
+    handler: setIsLabelOpen.off,
+  });
+
+  return (
+    <ChakraTooltip isOpen={isOpen} {...restToolTipProps}>
+      <chakra.div
+        onMouseEnter={setIsLabelOpen.on}
+        onMouseLeave={setIsLabelOpen.off}
+        onTouchStart={setIsLabelOpen.toggle}
+        ref={ref}
+        width={"fit-content"}
+      >
+        {children}
+      </chakra.div>
+    </ChakraTooltip>
+  );
+};

--- a/src/components/Tooltip/index.ts
+++ b/src/components/Tooltip/index.ts
@@ -1,0 +1,2 @@
+export { Tooltip } from "./Tooltip";
+export type { TooltipProps } from "./Tooltip";

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -13,3 +13,4 @@ export * from "./Table";
 export * from "./Transitions";
 export * from "./Modal";
 export * from "./Skeleton";
+export * from "./Tooltip";

--- a/src/theme/components/index.ts
+++ b/src/theme/components/index.ts
@@ -14,6 +14,7 @@ import { tableTheme } from "./table";
 import { tabsTheme } from "./tabs";
 import { modalTheme } from "./modal";
 import { skeletonTheme } from "./skeleton";
+import { tooltipTheme } from "./tooltip";
 
 export const components = {
   Accordion: accordionTheme,
@@ -32,4 +33,5 @@ export const components = {
   Tabs: tabsTheme,
   Modal: modalTheme,
   Skeleton: skeletonTheme,
+  Tooltip: tooltipTheme,
 };

--- a/src/theme/components/tooltip.ts
+++ b/src/theme/components/tooltip.ts
@@ -1,0 +1,7 @@
+import { tooltipTheme } from "@chakra-ui/theme/components/tooltip";
+
+if (tooltipTheme.baseStyle) {
+  tooltipTheme.baseStyle.py = "2";
+}
+
+export { tooltipTheme };


### PR DESCRIPTION
## Summary

This PR adds a customized version of Chakra's built in [Tooltip](https://v2.chakra-ui.com/docs/components/tooltip) component. Chakra v2's Tooltip has a limitation where it doesn't register click events so it never shows up for users using touch screens. I built a simple wrapper component, [heavily based on this solution](https://github.com/chakra-ui/chakra-ui/issues/2691#issuecomment-1560786121) mentioned in a Chakra issue. The result is a component that uses hover effects as expected for mouse users. For touch device users, the tooltip shows when the anchor is clicked and closes when it is clicked again or when the user clicks anywhere outside the tooltip.