### PR TITLE
144 Specify border color for button disabled status

### DIFF
--- a/src/theme/components/button.ts
+++ b/src/theme/components/button.ts
@@ -94,7 +94,7 @@ export const buttonTheme = defineStyleConfig({
         { borderTopWidth: "1px" },
       _disabled: {
         backgroundColor: "gray.50",
-        borderColor: "primary.600",
+        borderColor: "gray.400",
         color: "gray.700",
         opacity: 0.64,
         pointerEvents: "none",


### PR DESCRIPTION
Updated the border color of the secondary button variant's disabled state to "gray.400".

Closes #144 